### PR TITLE
#39 CORS and Readme for Firefox

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@ This project was generated with [Angular CLI](https://github.com/angular/angular
 
 Run `ng serve --watch --ssl` for a dev server. Navigate to `https://localhost:4200/`. The app will automatically reload if you change any of the source files. The `--ssl` and https protocol are necessary for Firefox.
 
+For firefox, exceptions need to be made for https://localhost:4200 and https://localhost:44377
+1. Navigate to https://localhost:4200 while the build/watch is running
+2. Click the security lock icon
+3. Click the settings gear under permissions
+4. Click "View Certificates" at the bottom
+5. Click "Servers"
+6. Click "Add Exception"
+6. a) In the "Location" text box, add https://localhost:4200
+   b) Click "Confirm Security Exception"
+7. Repeat step 6, using "https://localhost:44377" for the location in 6a 
+
 ## Code scaffolding
 
 Run `ng generate component component-name` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module`.

--- a/api/Startup.cs
+++ b/api/Startup.cs
@@ -65,8 +65,7 @@ namespace api
 				o.AddPolicy("AllowOrigin",
 					b => b.WithOrigins(domain)
 						.AllowAnyHeader()
-						.AllowAnyMethod()
-						.AllowCredentials()));
+						.AllowAnyMethod()));
 
 			services.AddScoped<IDbInitializer, DbInitializer>();
 


### PR DESCRIPTION
-Added the 'allow credentials' option to the CORS preflight response
-Updated readme to signify that you have to host the client in an SSL environment